### PR TITLE
ci(codecov): removes commit status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project: no
+    patch: no
+    changes: no


### PR DESCRIPTION
Removing codecov from the status checks. The comment it leaves is fine enough for the reviewer to triage.