### PR TITLE
fix(create-glamorous): forward nativeProps to inner component

### DIFF
--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -46,6 +46,11 @@ export default function createGlamorous(splitProps) {
         state = {theme: null}
         setTheme = theme => this.setState({theme})
 
+        constructor(props, context) {
+          super(props, context)
+          this.onRef = this.onRef.bind(this)
+        }
+
         componentWillMount() {
           const {theme} = this.props
 
@@ -72,6 +77,19 @@ export default function createGlamorous(splitProps) {
           this.unsubscribe && this.unsubscribe()
         }
 
+        setNativeProps(nativeProps) {
+          if (this.innerComponent) {
+            this.innerComponent.setNativeProps(nativeProps)
+          }
+        }
+
+        onRef(innerComponent) {
+          this.innerComponent = innerComponent
+          if (this.props.innerRef) {
+            this.props.innerRef(innerComponent)
+          }
+        }
+
         render() {
           const props = this.props
 
@@ -93,7 +111,7 @@ export default function createGlamorous(splitProps) {
 
           return React.createElement(GlamorousComponent.comp, {
             ...toForward,
-            ref: props.innerRef,
+            ref: this.onRef,
             style: fullStyles.length > 0 ? fullStyles : null,
           })
         }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: #28 points out that `Tocuhable` components wrapping `glamorous` components result in **native prop** forwarding failures. This is because the `glamorous` components do not implement `setNativeProps`

<!-- Why are these changes necessary? -->
**Why**: To allow native property forwarding

<!-- How were these changes implemented? -->
**How**: `setNativeProps` is added to the `glamorous` component

The following problematic code now works:

```js
<TouchableHighlight>
  <glamorous.View />
</TouchableHighlight>
```

Note: this was verified hands-on, and was unable to verify in units due to https://github.com/robinpowered/glamorous-native/issues/32

Closes #28