### PR TITLE
feat(glamorous): add camel case aliases to builtin component factories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ Object.assign(
   reactNativeElements.reduce((getters, key) => {
     const tag = key.toLowerCase()
     getters[tag] = glamorous(ReactNativeElementMap[key])
+    // backward compatible camel case
+    getters[camelCase(key)] = getters[tag]
     return getters
   }, {}),
 )
@@ -26,6 +28,10 @@ Object.assign(
     return comps
   }, {}),
 )
+
+function camelCase(tagName) {
+  return tagName.slice(0, 1).toLowerCase() + tagName.slice(1)
+}
 
 export default glamorous
 export {ThemeProvider, withTheme}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds camel cased factory functions, previously `glamorous.touchablehighlight`, and now in addition (to avoid breaking changes) `glamorous.touchableHighlight`

<!-- Why are these changes necessary? -->
**Why**: Expected function naming

<!-- How were these changes implemented? -->
**How**: Added as an alias, rather than a replacement, to avoid breaking changes


<!-- feel free to add additional comments -->
