### PR TITLE
fix(react-native-elements): support earlier versions of react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     ]
   },
   "peerDependencies": {
-    "react": ">=15.4.0 || >=16.0.0-alpha.6",
-    "react-native": ">=0.40"
+    "react": ">=0.14.5 || >=16.0.0-alpha.6",
+    "react-native": "^0.14.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "^1.9.2",

--- a/src/react-native-elements.js
+++ b/src/react-native-elements.js
@@ -14,11 +14,9 @@ import {
 } from 'react-native'
 
 export const ReactNativeElementMap = {
-  FlatList,
   Image,
   ListView,
   ScrollView,
-  SectionList,
   Text,
   TextInput,
   TouchableHighlight,
@@ -26,6 +24,16 @@ export const ReactNativeElementMap = {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
+}
+
+// Gracefully append new components that may not be supported
+// in earlier React Native versions
+if (FlatList) {
+  ReactNativeElementMap.FlatList = FlatList
+}
+
+if (SectionList) {
+  ReactNativeElementMap.SectionList = SectionList
 }
 
 export default Object.keys(ReactNativeElementMap)


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds support for versions of React Native dating back to `react-native@0.14.x`

<!-- Why are these changes necessary? -->
**Why**: Not all users are on the latest version

<!-- How were these changes implemented? -->
**How**: Lowers the dependency versions, as well as gracefully including support for newer React Native components only when they exist in the version of the dependent.

This fix has been verified in this test project on `react-native@0.14.x` https://github.com/ajwhite/glamorous-with-legacy-react-native


<!-- feel free to add additional comments -->

Closes #25