### PR TITLE
fix(package): use >= instead of caret for 0.x peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14.5 || >=16.0.0-alpha.6",
-    "react-native": "^0.14.0"
+    "react-native": ">=0.14.0 && < 1"
   },
   "devDependencies": {
     "babel-preset-react-native": "^1.9.2",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: `peerDependencies` are not being satisfied when they should.

<!-- Why are these changes necessary? -->
**Why**: Semver treats `0.x` releases with tighter constraints as they are considered pre-releases. React Native is on a `0.x` version, which means our `"peerDepdencies": "^0.14.0"` is not satisfied by other `0.x` releases.

![screen shot 2017-05-22 at 1 00 54 pm](https://cloud.githubusercontent.com/assets/656630/26319869/b66ae844-3eee-11e7-818a-1119c04ff1a8.png)


<!-- How were these changes implemented? -->
**How**: This now uses `>=` for evaluating `react-native` dependency versions


<!-- feel free to add additional comments -->
