### PR TITLE
feat(context): add dynamic style context support

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -370,3 +370,21 @@ test('should recieve inner ref if specified', () => {
   expect(getRef).toHaveBeenCalled()
 })
 */
+
+it('should accept user defined contextTypes', () => {
+  const dynamicStyles = jest.fn()
+  const Child = glamorous.view(dynamicStyles)
+  Child.contextTypes = {
+    fontSize: React.PropTypes.number,
+  }
+
+  const context = {
+    fontSize: 24,
+  }
+
+  shallow(<Child />, {context})
+  expect(dynamicStyles).toHaveBeenCalledTimes(1)
+  const theme = {}
+  const props = {}
+  expect(dynamicStyles).toHaveBeenCalledWith(props, theme, context)
+})

--- a/src/__tests__/tiny.test.js
+++ b/src/__tests__/tiny.test.js
@@ -22,12 +22,11 @@ test('should pass glam object prop', () => {
     ).toJSON(),
   ).toMatchSnapshot()
   expect(dynamicStyles).toHaveBeenCalledTimes(1)
-  expect(dynamicStyles).toHaveBeenCalledWith(
-    {
-      glam,
-      accessible: true,
-      theme, // this is just insidental because we have a theme prop
-    },
-    theme,
-  )
+  const props = {
+    glam,
+    accessible: true,
+    theme, // this is just incidental because we have a theme prop
+  }
+  const context = expect.any(Object)
+  expect(dynamicStyles).toHaveBeenCalledWith(props, theme, context)
 })

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -29,20 +29,6 @@ export default function createGlamorous(splitProps) {
       const styles = prepareStyles(unpreparedStyles)
 
       class GlamorousComponent extends React.Component {
-        static comp = comp
-        static propTypes = {
-          innerRef: PropTypes.func,
-          theme: PropTypes.object,
-        }
-
-        static contextTypes = {
-          [CHANNEL]: PropTypes.object,
-        }
-
-        static propTypes = {
-          // @TODO
-        }
-
         state = {theme: null}
         setTheme = theme => this.setState({theme})
 
@@ -107,6 +93,7 @@ export default function createGlamorous(splitProps) {
             props,
             styleOverrides,
             theme,
+            this.context,
           )
 
           return React.createElement(GlamorousComponent.comp, {
@@ -118,6 +105,37 @@ export default function createGlamorous(splitProps) {
       }
 
       GlamorousComponent.comp = comp
+
+      GlamorousComponent.propTypes = {
+        innerRef: PropTypes.func,
+        theme: PropTypes.object,
+      }
+
+      const defaultContextTypes = {
+        [CHANNEL]: PropTypes.object,
+      }
+      let userDefinedContextTypes = null
+
+      // configure the contextTypes to be settable by the user,
+      // however also retaining the glamorous channel.
+      Object.defineProperty(GlamorousComponent, 'contextTypes', {
+        enumerable: true,
+        configurable: true,
+        set(value) {
+          userDefinedContextTypes = value
+        },
+        get() {
+          // if the user has provided a contextTypes definition,
+          // merge the default context types with the provided ones.
+          if (userDefinedContextTypes) {
+            return {
+              ...defaultContextTypes,
+              ...userDefinedContextTypes,
+            }
+          }
+          return defaultContextTypes
+        },
+      })
 
       Object.assign(
         GlamorousComponent,

--- a/src/get-styles.js
+++ b/src/get-styles.js
@@ -1,14 +1,14 @@
-function evaluateGlamorStyles(styles, props, theme) {
+function evaluateGlamorStyles(styles, props, theme, context) {
   return styles.map(style => {
     if (typeof style === 'function') {
-      return style(props, theme)
+      return style(props, theme, context)
     }
     return style
   })
 }
 
-export default function getStyles(styles, props, styleOverrides, theme) {
-  const glamorStyles = evaluateGlamorStyles(styles, props, theme)
+function getStyles(styles, props, styleOverrides, theme, context) {
+  const glamorStyles = evaluateGlamorStyles(styles, props, theme, context)
   const outputStyles = glamorStyles
 
   if (styleOverrides && Object.keys(styleOverrides).length > 0) {
@@ -21,3 +21,5 @@ export default function getStyles(styles, props, styleOverrides, theme) {
 
   return outputStyles
 }
+
+export default getStyles


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Support for React's `context` in dynamic styles

<!-- Why are these changes necessary? -->
**Why**: Because you couldn't before!

<!-- How were these changes implemented? -->
**How**: `context` is now a third parameter in a dynamic styles function

```js
const View = glamorous.view(
  (props, theme, context) => ({ /* style with context */ })
)
```


<!-- feel free to add additional comments -->
