### PR TITLE
fix(getStyles): styles-as-properties priority

### DIFF
--- a/src/__tests__/__snapshots__/glamorous.test.js.snap
+++ b/src/__tests__/__snapshots__/glamorous.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`styles as properties should have highest priority 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "blue",
+      },
+      Object {
+        "backgroundColor": "blue",
+      },
+    ]
+  }
+/>
+`;

--- a/src/__tests__/glamorous.test.js
+++ b/src/__tests__/glamorous.test.js
@@ -15,6 +15,7 @@ import {
   StyleSheet,
 } from 'react-native'
 import {shallow} from 'enzyme'
+import renderer from 'react-test-renderer'
 import glamorous from '../'
 
 describe('test', () => {
@@ -98,4 +99,13 @@ describe('default components', () => {
   expect(shallow(<glamorous.TouchableWithoutFeedback />)
     .find(TouchableWithoutFeedback)).toBeDefined()
   expect(shallow(<glamorous.View />).find(View)).toBeDefined()
+})
+
+it('styles as properties should have highest priority', () => {
+  expect(renderer.create(
+    <glamorous.View
+      style={{backgroundColor: 'green'}}
+      backgroundColor="blue"
+    />,
+  ).toJSON()).toMatchSnapshot()
 })

--- a/src/get-styles.js
+++ b/src/get-styles.js
@@ -11,12 +11,12 @@ export default function getStyles(styles, props, styleOverrides, theme) {
   const glamorStyles = evaluateGlamorStyles(styles, props, theme)
   const outputStyles = glamorStyles
 
-  if (styleOverrides && Object.keys(styleOverrides).length > 0) {
-    outputStyles.push(styleOverrides)
-  }
-
   if (props.style) {
     outputStyles.push(props.style)
+  }
+
+  if (styleOverrides && Object.keys(styleOverrides).length > 0) {
+    outputStyles.push(styleOverrides)
   }
 
   return outputStyles


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: #35 styles-as-properties had lower priority than `style` property

```js
<glamorous.View
  style={{backgroundColor: 'green'}}
  backgroundColor="blue"
/>
// should have `blue` background
```

<!-- Why are these changes necessary? -->
**Why**: The styles-as-properties should have the highest priority

<!-- How were these changes implemented? -->
**How**: These are now the last styles added to the component's style array


<!-- feel free to add additional comments -->
