### PR TITLE
feat(glamorous): export builtin components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,5 +33,20 @@ function camelCase(tagName) {
   return tagName.slice(0, 1).toLowerCase() + tagName.slice(1)
 }
 
+// @TODO: automate the named exports
+export const Image = glamorous.Image
+export const ListView = glamorous.ListView
+export const ScrollView = glamorous.ScrollView
+export const Text = glamorous.Text
+export const TextInput = glamorous.TextInput
+export const TouchableHighlight = glamorous.TouchableHighlight
+export const TouchableNativeFeedback = glamorous.TouchableNativeFeedback
+export const TouchableOpacity = glamorous.TouchableOpacity
+export const TouchableWithoutFeedback = glamorous.TouchableWithoutFeedback
+export const View = glamorous.View
+// These are only on `glamorous` if the version of ReactNative supports them
+export const FlatList = glamorous.FlatList
+export const SectionList = glamorous.SectionList
+
 export default glamorous
 export {ThemeProvider, withTheme}


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Builtin components are now exported

```js
import {View} from 'glamorous-native'

<View height={300} width={300}>..</View>
```

<!-- Why are these changes necessary? -->
**Why**: Because it makes life easier 😅 

<!-- How were these changes implemented? -->
**How**: Each builtin component is manually exported. In the future, it would be nice to do something a bit more automated, such as in https://github.com/paypal/glamorous/pull/131. Exports have to be known statically, so they can't be dynamically generated.


<!-- feel free to add additional comments -->
