### PR TITLE
fix(styles): StyleSheet style blocked styleOverrides

### DIFF
--- a/src/__tests__/__snapshots__/glamorous.test.js.snap
+++ b/src/__tests__/__snapshots__/glamorous.test.js.snap
@@ -5,7 +5,7 @@ exports[`styles as properties should have highest priority 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "blue",
+        "backgroundColor": "green",
       },
       Object {
         "backgroundColor": "blue",

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -11,9 +11,6 @@ exports[`allows you to specify the tag rendered by a component 1`] = `
       Object {
         "width": 2,
       },
-      Object {
-        "width": 2,
-      },
     ]
   }
 />
@@ -45,19 +42,6 @@ exports[`merges composed component styles for reasonable overrides 1`] = `
         "marginBottom": 3,
         "marginLeft": 3,
       },
-      Array [
-        Object {
-          "marginLeft": 4,
-          "paddingTop": 4,
-        },
-        Object {
-          "paddingRight": 5,
-          "paddingTop": 5,
-        },
-        Object {
-          "paddingRight": 6,
-        },
-      ],
       Array [
         Object {
           "marginLeft": 4,

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -45,7 +45,7 @@ test('can use pre-glamorous components with style prop', () => {
       />,
     ).props(),
   ).toMatchObject({
-    style: [{flex: 1, flexDirection: 'column'}, {width: 200, marginLeft: 24}],
+    style: [{width: 200, marginLeft: 24}, {flex: 1, flexDirection: 'column'}],
   })
 })
 

--- a/src/split-props.js
+++ b/src/split-props.js
@@ -5,12 +5,12 @@ function shouldForwardProperty(rootEl, propName) {
 }
 
 export default function splitProps({
-  style: styleOverrides = {},
   theme,
   innerRef,
   glam,
   ...rest
 }, {propsAreStyleOverrides, rootEl, forwardProps}) {
+  const styleOverrides = {}
   const returnValue = {toForward: {}, styleOverrides}
 
   if (!propsAreStyleOverrides) {


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fixes an issue when `style={aNumber}` (from a `StyleSheet` entry). This leads to a problem where built-in components (any component using `propsAreStyleOverrides`), because it expects `props.style` to be an `Object` that it can add to. 

<!-- Why are these changes necessary? -->
**Why**: Any `propsAreStyleOverrides` props will be ignored when `style={aNumber}`

<!-- How were these changes implemented? -->
**How**: Instead of sharing the `props.style` in `splitProps`, we instead maintain an independent object. We actually don't need to use this, because `getStyle` uses it independently from `styleOverrides` already 🙌 

This also explains why there were duplicate styles showing up when `style={anObject}` in conjunction with `propsAreStyleOverrides` -- the style was being added to two objects 


<!-- feel free to add additional comments -->
