### PR TITLE
Do not give refs to stateless function components

### DIFF
--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -96,9 +96,13 @@ export default function createGlamorous(splitProps) {
             this.context,
           )
 
+          const isStatelessFunction =
+            typeof GlamorousComponent.comp === 'function' &&
+            !GlamorousComponent.comp.prototype.render
+
           return React.createElement(GlamorousComponent.comp, {
             ...toForward,
-            ref: this.onRef,
+            ref: isStatelessFunction ? undefined : this.onRef,
             style: fullStyles.length > 0 ? fullStyles : null,
           })
         }


### PR DESCRIPTION
Some of my components are stateless functions, they accept style prop and pass it down to children. I want to style them with glamorous. However, I get annoying yellowbox warnings like this

```
Warning: Stateless function components cannot be given refs. Attempts to access this ref will fail.

Check the render method of `Icon`.
    in IconBase (created by Icon)
    in Icon (at PhotoPickerItem.js:51)
```
 where `IconBase` is stateless function and `Icon` is `glamorous(IconBase, { displayName: 'Icon' })(...)`. If I replace IconBase with class, those warning no longer appear.

So I added this simple condition. Glamorous component factory now checks if wrapped component is stateless function, and if so, it will not give it ref

I tries this with react-native 0.45.1, I did a quick search and I think this exactly warning message was introduced recently, so in older versions of react-native it might not be displayed or have different message.