### PR TITLE
Add note about configuring Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ From here you can now import this module:
 import glamorous, {ThemeProvider} from 'glamorous-native'
 ```
 
+### Jest Configuration
+
+To use `glamorous-native` in Jest (such as with snapshot tests), you need to configure the `transformIgnorePatterns` configuration in your `package.json`. [More documentation about this can be found here](https://facebook.github.io/jest/docs/tutorial-react-native.html#transformignorepatterns-customization).
+
+```json
+{
+  "jest": {
+    "preset": "react-native",
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|glamorous-native)"
+    ]
+  }
+}
+```
+
 ## Terms and concepts
 
 ### glamorous


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Add note about configuring Jest 

<!-- Why are these changes necessary? -->
**Why**: 
Since this module doesn't need to be transformed by Babel, we need to tell Jest not to try to transform it.

This fixes errors like `({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import createGlamorous from './create-glamorous'`

<!-- How were these changes implemented? -->
**How**:
By using my keyboard to add the words to the text editor on my screen. 😅