### PR TITLE
Consume PropTypes from the prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node-jsdom": "^3.1.5",
     "nps": "^5.1.0",
     "nps-utils": "^1.2.0",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.6",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
@@ -55,8 +56,7 @@
     "semantic-release": "^6.3.6"
   },
   "dependencies": {
-    "brcast": "^2.0.0",
-    "prop-types": "^15.5.10"
+    "brcast": "^2.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "semantic-release": "^6.3.6"
   },
   "dependencies": {
-    "brcast": "^2.0.0"
+    "brcast": "^2.0.0",
+    "prop-types": "^15.5.10"
   },
   "eslintConfig": {
     "extends": [

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,6 +1,7 @@
 /* eslint func-style:0, react/prop-types:0 */
 import 'react-native-mock-render/mock' // eslint-disable-line
 import React from 'react'
+import PropTypes from 'prop-types'
 import {StyleSheet, View} from 'react-native'
 import renderer from 'react-test-renderer'
 import {shallow} from 'enzyme'
@@ -375,7 +376,7 @@ it('should accept user defined contextTypes', () => {
   const dynamicStyles = jest.fn()
   const Child = glamorous.view(dynamicStyles)
   Child.contextTypes = {
-    fontSize: React.PropTypes.number,
+    fontSize: PropTypes.number,
   }
 
   const context = {

--- a/src/__tests__/with-theme.test.js
+++ b/src/__tests__/with-theme.test.js
@@ -1,5 +1,7 @@
 /* eslint func-style:0, react/prop-types:0 */
-import React, {PropTypes} from 'react'
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {View} from 'react-native'
 import renderer from 'react-test-renderer'
 

--- a/src/__tests__/with-theme.test.js
+++ b/src/__tests__/with-theme.test.js
@@ -1,7 +1,6 @@
 /* eslint func-style:0, react/prop-types:0 */
-import PropTypes from 'prop-types';
-
-import React from 'react';
+import React from 'react'
+import PropTypes from 'prop-types'
 import {View} from 'react-native'
 import renderer from 'react-test-renderer'
 

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -1,8 +1,8 @@
-import PropTypes from './react-compat';
-import React from 'react';
+import React from 'react'
 import {StyleSheet} from 'react-native'
 import {CHANNEL} from './constants'
 import getStyles from './get-styles'
+import PropTypes from './react-compat'
 
 function prepareStyles(styles) {
   return styles.filter(style => {

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import PropTypes from 'prop-types';
+import React from 'react';
 import {StyleSheet} from 'react-native'
 import {CHANNEL} from './constants'
 import getStyles from './get-styles'

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from './react-compat';
 import React from 'react';
 import {StyleSheet} from 'react-native'
 import {CHANNEL} from './constants'

--- a/src/react-compat.js
+++ b/src/react-compat.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+// eslint-disable-next-line import/no-mutable-exports
+let PropTypes
+
+if (parseFloat(React.version.slice(0, 4)) >= 15.5) {
+  try {
+    PropTypes = require('prop-types')
+  } catch (error) {
+    // ignore
+  }
+}
+PropTypes = PropTypes || React.PropTypes
+
+export default PropTypes

--- a/src/theme-provider.js
+++ b/src/theme-provider.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import PropTypes from 'prop-types';
+import React from 'react';
 import brcast from 'brcast'
 import {CHANNEL} from './constants'
 

--- a/src/theme-provider.js
+++ b/src/theme-provider.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from './react-compat';
 import React from 'react';
 import brcast from 'brcast'
 import {CHANNEL} from './constants'

--- a/src/theme-provider.js
+++ b/src/theme-provider.js
@@ -1,7 +1,7 @@
-import PropTypes from './react-compat';
-import React from 'react';
+import React from 'react'
 import brcast from 'brcast'
 import {CHANNEL} from './constants'
+import PropTypes from './react-compat'
 
 export default class ThemeProvider extends React.Component {
   static childContextTypes = {

--- a/src/with-theme.js
+++ b/src/with-theme.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import PropTypes from 'prop-types';
+import React from 'react';
 import {CHANNEL} from './constants'
 
 function generateWarningMessage(componentName) {

--- a/src/with-theme.js
+++ b/src/with-theme.js
@@ -1,6 +1,6 @@
-import PropTypes from './react-compat';
-import React from 'react';
+import React from 'react'
 import {CHANNEL} from './constants'
+import PropTypes from './react-compat'
 
 function generateWarningMessage(componentName) {
   // eslint-disable-next-line max-len

--- a/src/with-theme.js
+++ b/src/with-theme.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from './react-compat';
 import React from 'react';
 import {CHANNEL} from './constants'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,7 +5089,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
**What**:

Adds `prop-types` module and runs the [`React-PropTypes-to-prop-types` codemod](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types)

<!-- Why are these changes necessary? -->
**Why**:

This ensures compatibility with React 16+. Fixes `Cannot read property 'object' of undefined` on React 16.0.0-beta.1

![screen shot 2017-07-28 at 4 59 14 pm](https://user-images.githubusercontent.com/1051453/28736067-34abd5b4-73b6-11e7-9184-1fbaec1f62d1.png)

<!-- How were these changes implemented? -->
**How**:
```bash
$ cd glamorous-native
$ yarn add prop-types
$ cd .. && git clone https://github.com/reactjs/react-codemod.git
$ jscodeshift -t react-codemod/transforms/React-PropTypes-to-prop-types.js ../glamorous-native/src`
```
