### PR TITLE
Moved Theme to Props

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /* eslint func-style:0, react/prop-types:0 */
-import 'react-native-mock-render/mock' // eslint-disable-line
+import 'react-native-mock-render/mock'; // eslint-disable-line
 import React from 'react'
 import PropTypes from 'prop-types'
 import {StyleSheet, View} from 'react-native'
@@ -25,12 +25,7 @@ test('sanity test', () => {
 
 test('can use pre-glamorous components with style attributes', () => {
   expect(
-    shallow(
-      <glamorous.View
-        flex={1}
-        flexDirection="column"
-      />,
-    ).props(),
+    shallow(<glamorous.View flex={1} flexDirection="column" />).props(),
   ).toMatchObject({
     style: [{flex: 1, flexDirection: 'column'}],
   })
@@ -46,7 +41,10 @@ test('can use pre-glamorous components with style prop', () => {
       />,
     ).props(),
   ).toMatchObject({
-    style: [{width: 200, marginLeft: 24}, {flex: 1, flexDirection: 'column'}],
+    style: [
+      {width: 200, marginLeft: 24},
+      {flex: 1, flexDirection: 'column'},
+    ],
   })
 })
 
@@ -77,18 +75,18 @@ test('merges composed component styles for reasonable overrides', () => {
   })
 
   const wrapper = shallow(
-    <Grandchild
-      style={[otherStyles1, otherStyles2, {paddingRight: 6}]}
-    />,
+    <Grandchild style={[otherStyles1, otherStyles2, {paddingRight: 6}]} />,
   )
 
   const computedStyles = StyleSheet.flatten(wrapper.props().style)
 
-  expect(renderer.create(
-    <Grandchild
-      style={[otherStyles1, otherStyles2, {paddingRight: 6}]}
-    />,
-  ).toJSON()).toMatchSnapshot()
+  expect(
+    renderer
+      .create(
+        <Grandchild style={[otherStyles1, otherStyles2, {paddingRight: 6}]} />,
+      )
+      .toJSON(),
+  ).toMatchSnapshot()
 
   expect(computedStyles).toMatchObject({
     marginTop: 1,
@@ -154,9 +152,15 @@ test('allows you to specify the tag rendered by a component', () => {
     width: 1,
   })
   expect(
-    renderer.create(
-      <MyStyledViewComponent height={2} noForward={true} style={{width: 2}} />,
-    ).toJSON(),
+    renderer
+      .create(
+        <MyStyledViewComponent
+          height={2}
+          noForward={true}
+          style={{width: 2}}
+        />,
+      )
+      .toJSON(),
   ).toMatchSnapshot()
 })
 
@@ -237,7 +241,7 @@ test('renders a component with theme properties', () => {
     {
       backgroundColor: 'red',
     },
-    (props, theme) => ({padding: theme.padding}),
+    ({theme}) => ({padding: theme.padding}),
   )
   expect(
     renderer.create(<Comp theme={{padding: '10px'}} />).toJSON(),
@@ -292,7 +296,7 @@ test('passes an updated theme when theme prop changes', () => {
     {
       backgroundColor: 'red',
     },
-    (props, theme) => ({padding: theme.padding}),
+    ({theme}) => ({padding: theme.padding}),
   )
   const wrapper = shallow(<Comp theme={{padding: 10}} />)
   expect(wrapper.props()).toMatchObject({
@@ -386,6 +390,6 @@ it('should accept user defined contextTypes', () => {
   shallow(<Child />, {context})
   expect(dynamicStyles).toHaveBeenCalledTimes(1)
   const theme = {}
-  const props = {}
+  const props = {theme}
   expect(dynamicStyles).toHaveBeenCalledWith(props, theme, context)
 })

--- a/src/__tests__/theme-provider.test.js
+++ b/src/__tests__/theme-provider.test.js
@@ -4,6 +4,7 @@ import {shallow} from 'enzyme'
 import ThemeProvider from '../theme-provider'
 import glamorous from '../'
 
+// this test left to validate changes don't break contract
 test('renders a component with theme', () => {
   const Comp = glamorous.view(
     {
@@ -20,7 +21,35 @@ test('renders a component with theme', () => {
 
   wrapper.instance().componentWillMount()
 
-  const compWrapper = wrapper.find(Comp)
+  const compWrapper = wrapper
+    .find(Comp)
+    .shallow({context: wrapper.instance().getChildContext()})
+
+  compWrapper.instance().componentWillMount()
+
+  expect(compWrapper.props()).toMatchObject({
+    style: [{backgroundColor: 'red'}, {padding: 10}],
+  })
+})
+
+test('renders a component with theme from props', () => {
+  const Comp = glamorous.view(
+    {
+      backgroundColor: 'red',
+    },
+    props => ({padding: props.theme.padding}),
+  )
+
+  const wrapper = shallow(
+    <ThemeProvider theme={{padding: 10}}>
+      <Comp />
+    </ThemeProvider>,
+  )
+
+  wrapper.instance().componentWillMount()
+
+  const compWrapper = wrapper
+    .find(Comp)
     .shallow({context: wrapper.instance().getChildContext()})
 
   compWrapper.instance().componentWillMount()
@@ -49,7 +78,7 @@ test('theme properties updates get propagated down the tree', () => {
     {
       backgroundColor: 'red',
     },
-    (props, theme) => ({padding: theme.padding}),
+    props => ({padding: props.theme.padding}),
   )
 
   const wrapper = shallow(<Parent />)
@@ -58,7 +87,8 @@ test('theme properties updates get propagated down the tree', () => {
 
   themeWrapper.instance().componentWillMount()
 
-  const compWrapper = wrapper.find(Child)
+  const compWrapper = wrapper
+    .find(Child)
     .shallow({context: themeWrapper.instance().getChildContext()})
 
   compWrapper.instance().componentWillMount()
@@ -69,12 +99,12 @@ test('theme properties updates get propagated down the tree', () => {
 })
 
 test('merges nested themes', () => {
-  const One = glamorous.view({}, (props, {padding, margin}) => ({
+  const One = glamorous.view({}, ({theme: {padding, margin}}) => ({
     padding,
     margin,
   }))
 
-  const Two = glamorous.view({}, (props, {padding, margin}) => ({
+  const Two = glamorous.view({}, ({theme: {padding, margin}}) => ({
     padding,
     margin,
   }))
@@ -91,15 +121,18 @@ test('merges nested themes', () => {
   )
 
   wrapper.instance().componentWillMount()
-  const oneWrapper = wrapper.find(One)
+  const oneWrapper = wrapper
+    .find(One)
     .shallow({context: wrapper.instance().getChildContext()})
   oneWrapper.instance().componentWillMount()
 
-  const innerThemeWrapper = wrapper.find(ThemeProvider)
+  const innerThemeWrapper = wrapper
+    .find(ThemeProvider)
     .shallow({context: wrapper.instance().getChildContext()})
   innerThemeWrapper.instance().componentWillMount()
 
-  const twoWrapper = innerThemeWrapper.find(Two)
+  const twoWrapper = innerThemeWrapper
+    .find(Two)
     .shallow({context: innerThemeWrapper.instance().getChildContext()})
   twoWrapper.instance().componentWillMount()
 

--- a/src/__tests__/tiny.test.js
+++ b/src/__tests__/tiny.test.js
@@ -17,9 +17,9 @@ test('should pass glam object prop', () => {
   const glam = {big: true}
   const theme = {color: 'blue'}
   expect(
-    renderer.create(
-      <Comp accessible={true} glam={glam} theme={theme} />,
-    ).toJSON(),
+    renderer
+      .create(<Comp accessible={true} glam={glam} theme={theme} />)
+      .toJSON(),
   ).toMatchSnapshot()
   expect(dynamicStyles).toHaveBeenCalledTimes(1)
   const props = {

--- a/src/get-styles.js
+++ b/src/get-styles.js
@@ -1,7 +1,7 @@
 function evaluateGlamorStyles(styles, props, theme, context) {
   return styles.map(style => {
     if (typeof style === 'function') {
-      return style(props, theme, context)
+      return style(Object.assign({}, props, {theme}), theme, context)
     }
     return style
   })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Moving theme from second argument to a theme prop. 

<!-- Why are these changes necessary? -->
**Why**:
To match the glamorous-web api.

<!-- How were these changes implemented? -->
**How**:
- Updated tests
- updated `getStyles` til tests passed 😁

<!-- feel free to add additional comments -->

Talked with @kentcdodds about this at ReactRally. I will probably make an update to the code-mod so that it can catch the native cases as well. He also mentioned leaving it as a second prop to not break contract. I didn't do that in this case, but could be easily achieved if you want me to go that route let me know. 
