### PR TITLE
removed unavailable function interfaces

### DIFF
--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -13,20 +13,6 @@ export interface ExtraGlamorousProps {
   theme?: object
 }
 
-export interface WithComponent<ExternalProps, Props> {
-  withComponent: (
-    component: string | Component<Props>
-  ) => GlamorousComponent<ExternalProps, Props>
-}
-
-export interface WithProps<ExternalProps, Props> {
-  withProps: <DefaultProps extends object>(
-    props: DefaultProps
-  ) => GlamorousComponent<ExternalProps & Partial<DefaultProps>, Props>
-}
-
 export type GlamorousComponent<ExternalProps, Props> = React.ComponentClass<
   ExtraGlamorousProps & ExternalProps
-> &
-  WithComponent<ExternalProps, Props> &
-  WithProps<ExternalProps, Props>
+>

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -8,12 +8,7 @@ import {
   NativeComponentFactory,
   ComponentKey,
 } from './built-in-component-factories'
-import {
-  GlamorousComponent,
-  ExtraGlamorousProps,
-  WithComponent,
-  WithProps,
-} from './glamorous-component'
+import { GlamorousComponent, ExtraGlamorousProps } from './glamorous-component'
 import {
   BuiltInGlamorousComponentFactory,
   KeyGlamorousComponentFactory,
@@ -35,8 +30,6 @@ import {
 export {
   GlamorousComponent,
   ExtraGlamorousProps,
-  WithComponent,
-  WithProps,
   StyleFunction,
   StyleArray,
   StyleArgument,


### PR DESCRIPTION
I removed the interfaces WithComponent and WithProps, because those functions are not available in glamorous-native.

Thanks to @epeli  