### PR TITLE
Ensure Glamorous forward props to RCTView rootEl

### DIFF
--- a/src/split-props.js
+++ b/src/split-props.js
@@ -1,7 +1,11 @@
 import isStyleProp from './is-style-prop'
 
+function isForwardPropertyRootElement(rootEl) {
+  return typeof rootEl !== 'string' || rootEl === 'RCTView'
+}
+
 function shouldForwardProperty(rootEl, propName) {
-  return typeof rootEl !== 'string' && !isStyleProp(rootEl, propName)
+  return isForwardPropertyRootElement(rootEl) && !isStyleProp(rootEl, propName)
 }
 
 export default function splitProps({
@@ -14,7 +18,7 @@ export default function splitProps({
   const returnValue = {toForward: {}, styleOverrides}
 
   if (!propsAreStyleOverrides) {
-    if (typeof rootEl !== 'string') {
+    if (isForwardPropertyRootElement(rootEl)) {
       returnValue.toForward = rest
       return returnValue
     }


### PR DESCRIPTION
For undocumented reasons, importing View in recent versions of RN (RN50/Expo SDK23) does return string "RCTView" in prod, while in dev it returns a function.

It is the only component in RN codebase that behaves this way in prod build.

See for example ReactNativeElementMap log output:

```
17:17:30: ReactNativeElementMap Object {
17:17:30:   "FlatList": [Function FlatList],
17:17:30:   "Image": [Function anonymous],
17:17:30:   "ListView": [Function anonymous],
17:17:30:   "ScrollView": [Function anonymous],
17:17:30:   "SectionList": [Function SectionList],
17:17:30:   "Text": [Function anonymous],
17:17:30:   "TextInput": [Function anonymous],
17:17:30:   "TouchableHighlight": [Function anonymous],
17:17:30:   "TouchableNativeFeedback": [Function anonymous],
17:17:30:   "TouchableOpacity": [Function anonymous],
17:17:30:   "TouchableWithoutFeedback": [Function anonymous],
17:17:30:   "View": "RCTView",
17:17:30: }
```


Some code references in RN codebase that looks related:

https://github.com/facebook/react-native/blob/64d80b13db3dd28bb5d93cbedf511ae8f91e2127/Libraries/Components/View/View.js#L95
https://github.com/facebook/react-native/commit/9344f3a95b56833d29cd18438a94a0c22f67b0f8#diff-a562e4a7ac9e900c6d2bc644453e9152



should fix:

https://github.com/robinpowered/glamorous-native/issues/84
https://github.com/robinpowered/glamorous-native/issues/83
https://github.com/robinpowered/glamorous-native/issues/81
