### PR TITLE
Added ImageBackground to the supported elements

### DIFF
--- a/src/react-native-elements.js
+++ b/src/react-native-elements.js
@@ -11,6 +11,7 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
+  ImageBackground
 } from 'react-native'
 
 export const ReactNativeElementMap = {
@@ -24,6 +25,7 @@ export const ReactNativeElementMap = {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
+  ImageBackground
 }
 
 // Gracefully append new components that may not be supported

--- a/src/react-native-elements.js
+++ b/src/react-native-elements.js
@@ -25,7 +25,6 @@ export const ReactNativeElementMap = {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-  ImageBackground,
 }
 
 // Gracefully append new components that may not be supported
@@ -36,6 +35,10 @@ if (FlatList) {
 
 if (SectionList) {
   ReactNativeElementMap.SectionList = SectionList
+}
+
+if (ImageBackground) {
+  ReactNativeElementMap.ImageBackground = ImageBackground
 }
 
 export default Object.keys(ReactNativeElementMap)

--- a/src/react-native-elements.js
+++ b/src/react-native-elements.js
@@ -11,7 +11,7 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-  ImageBackground
+  ImageBackground,
 } from 'react-native'
 
 export const ReactNativeElementMap = {
@@ -25,7 +25,7 @@ export const ReactNativeElementMap = {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-  ImageBackground
+  ImageBackground,
 }
 
 // Gracefully append new components that may not be supported


### PR DESCRIPTION
- Added `ImageBackground` to the `ReactNativeElementMap` in react-native-elements.js

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: - Added `ImageBackground` to the `ReactNativeElementMap` in react-native-elements.js

<!-- Why are these changes necessary? -->
**Why**: When upgrading react native versions, the Image component can no longer have child components, so ImageBackground should be used instead

<!-- How were these changes implemented? -->
**How**: - Added `ImageBackground` to the `ReactNativeElementMap` in react-native-elements.js


<!-- feel free to add additional comments -->

  