### PR TITLE
feat(glamorous): Add propsAreStyleOverrides to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ const MyStyledComponent = glamorous(MyComponent, {
   fontSize: props.big ? 36 : 24
 }))
 <MyStyledComponent shouldRender={true} big={false} numberOfLines={1} />
-// this will render:
+// This will render:
 // <Text numberOfLines={1} />
 // with {fontSize: 24}
 // `shouldRender` will be forwarded to `MyComponent` because it is included in
@@ -409,6 +409,27 @@ const MyStyledComponent = glamorous(MyComponent, {
 // is a `Text` and that's not a valid prop for a `Text`, but it will be used in
 // the styles object function that determines the `fontSize`. Finally `numberOfLines`
 // will be forwarded to `MyComponent` because it is a valid prop for a `Text`
+```
+
+#### propsAreStyleOverrides
+
+This allows you to use props as styles. When it's set to true, props will be added to the component's style object, taking precedence over existing values. Pre-built components like `glamorous.text` use this option by default.
+
+```js
+const GreenText = glamorous(
+  Text,
+  {propsAreStyleOverrides: true}
+)({
+  color: 'green'
+})
+
+<GreenText fontSize={30} selectable={true} />
+// This will render:
+// <Text selectable={true} />
+// with {color: 'green', fontSize: 30}
+// the selectable prop is passed to the underlying
+// Text component because glamorous recognizes that
+// it's not a valid style property
 ```
 
 ### Theming

--- a/src/__tests__/__snapshots__/glamorous.test.js.snap
+++ b/src/__tests__/__snapshots__/glamorous.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`propsAreStyleOverrides should add style props to the style object 1`] = `
+<View
+  nonStyleProp={true}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "green",
+      },
+    ]
+  }
+/>
+`;
+
 exports[`styles as properties should have highest priority 1`] = `
 <View
   style={

--- a/src/__tests__/glamorous.test.js
+++ b/src/__tests__/glamorous.test.js
@@ -109,3 +109,16 @@ it('styles as properties should have highest priority', () => {
     />,
   ).toJSON()).toMatchSnapshot()
 })
+
+describe('propsAreStyleOverrides', () => {
+  it('should add style props to the style object', () => {
+    const StyledView = glamorous(View, {
+      propsAreStyleOverrides: true,
+    })()
+    expect(
+      renderer.create(
+        <StyledView backgroundColor="green" nonStyleProp={true} />,
+      ).toJSON(),
+    ).toMatchSnapshot()
+  })
+})

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -20,10 +20,12 @@ function prepareStyles(styles) {
 }
 
 export default function createGlamorous(splitProps) {
-  return function glamorous(
-    comp,
-    {rootEl, displayName, forwardProps = []} = {},
-  ) {
+  return function glamorous(comp, {
+      rootEl,
+      displayName,
+      forwardProps = [],
+      propsAreStyleOverrides = comp.propsAreStyleOverrides,
+    } = {}) {
     return glamorousComponentFactory
 
     function glamorousComponentFactory(...unpreparedStyles) {
@@ -155,6 +157,7 @@ export default function createGlamorous(splitProps) {
           rootEl,
           forwardProps,
           displayName,
+          propsAreStyleOverrides,
         }),
       )
 
@@ -169,6 +172,7 @@ function getGlamorousComponentMetadata({
   rootEl,
   forwardProps,
   displayName,
+  propsAreStyleOverrides,
 }) {
   const componentsComp = comp.comp ? comp.comp : comp
 
@@ -178,6 +182,7 @@ function getGlamorousComponentMetadata({
     rootEl: rootEl || componentsComp,
     forwardProps: when(comp.forwardProps, forwardProps),
     displayName: displayName || `glamorous(${getDisplayName(comp)})`,
+    propsAreStyleOverrides,
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!


Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Allow `propsAreStyleOverrides` to be defined in the glamorous config object

<!-- Why are these changes necessary? -->
**Why**: closes #80

<!-- How were these changes implemented? -->
**How**: Adds `propsAreStyleOverrides` to the config object; when that's not defined, it falls back to using `comp.propsAreStyleOverrides`.


<!-- feel free to add additional comments -->
