### PR TITLE
Update typings for rootEl

### DIFF
--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -45,7 +45,7 @@ export {
 
 export interface GlamorousOptions<Props, Context, DefaultProps> {
   displayName: string
-  rootEl: string | Element
+  rootEl: string | ComponentType<any>
   forwardProps: String[]
   shouldClassNameUpdate: (
     props: Props,
@@ -63,7 +63,7 @@ export interface PropsAreCssOverridesGlamorousOptions<
   DefaultProps
 > {
   displayName?: string
-  rootEl?: string | Element
+  rootEl?: string | ComponentType<any>
   forwardProps?: String[]
   shouldClassNameUpdate?: (
     props: Props,


### PR DESCRIPTION
Updated typings for rootEl.

Previously this wouldn't compile:

```ts
glamorous(ButtonText, {rootEl: Text})
```
because of Text not extending from Element.

If I'm not mistaken, Element is only used in the web version of React.