### PR TITLE
Update innerRef to allow React.createRef and React.forwardRef api usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,28 @@ class MyComponent extends React.Component {
 }
 ```
 
+innerRef also supports the new [React.createRef()](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) api
+
+```js
+const MyView = glamorous.view({padding: 20})
+
+// You can get a reference to the inner element with the `innerRef` prop
+
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+  render() {
+    return () {
+      return (
+        <MyView innerRef={this.myRef} />
+      )
+    }
+  }
+}
+```
+
 ##### other props
 
 Only props that are safe to forward to the specific element (ie. that will ultimately be rendered) will be forwarded. So this is totally legit:

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -72,11 +72,27 @@ export default function createGlamorous(splitProps) {
           }
         }
 
-        onRef(innerComponent) {
+        onRef = innerComponent => {
           this.innerComponent = innerComponent
-          if (this.props.innerRef) {
-            this.props.innerRef(innerComponent)
+          this.props.innerRef(innerComponent)
+        }
+
+        forwardedRef = () => {
+          const {innerRef} = this.props
+
+          const isStatelessFunction =
+          typeof GlamorousComponent.comp === 'function' &&
+          !GlamorousComponent.comp.prototype.render
+
+          if (!isStatelessFunction) {
+            if (innerRef && typeof innerRef === 'function') {
+              return this.onRef
+            }
+            if (innerRef && typeof innerRef === 'object') {
+              return innerRef
+            }
           }
+          return undefined
         }
 
         render() {
@@ -99,15 +115,12 @@ export default function createGlamorous(splitProps) {
             this.context,
           )
 
-          const isStatelessFunction =
-            typeof GlamorousComponent.comp === 'function' &&
-            !GlamorousComponent.comp.prototype.render
-
+        
           return React.createElement(
             GlamorousComponent.comp,
             {
               ...toForward,
-              ref: isStatelessFunction ? undefined : this.onRef,
+              ref: this.forwardedRef(),
               style: fullStyles.length > 0 ? fullStyles : null,
             },
             children,
@@ -119,7 +132,7 @@ export default function createGlamorous(splitProps) {
 
       GlamorousComponent.propTypes = {
         children: PropTypes.node,
-        innerRef: PropTypes.func,
+        innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         theme: PropTypes.object,
       }
 

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -1,6 +1,6 @@
-import { Component } from './glamorous'
+import {Component} from './glamorous'
 
-import { Omit } from './helpers'
+import {Omit} from './helpers'
 
 /**
 * `glamorousComponentFactory` returns a ComponentClass
@@ -9,7 +9,7 @@ import { Omit } from './helpers'
 */
 
 export interface ExtraGlamorousProps {
-  innerRef?: (instance: any) => void
+  innerRef?: React.Ref<{}>;
   theme?: object
 }
 


### PR DESCRIPTION
**What**: Updated inner ref prop to allow newer apis to be used

**Why**: innerRef currently does not support the new react.CreateRef() api, this merge will allow this new api to be used whilst maintaining support for the old callback method for innerRef. This will also allow support for the forwardRef api.