### PR TITLE
Fix RN typing breaking change: ViewProperties => ViewProps

### DIFF
--- a/typings/built-in-component-factories.d.ts
+++ b/typings/built-in-component-factories.d.ts
@@ -1,52 +1,52 @@
 import { BuiltInGlamorousComponentFactory } from './component-factory'
 
 import {
-  ViewProperties,
+  ViewProps,
   TextStyle,
   ViewStyle,
   ImageStyle,
-  TextInputProperties,
-  ImageProperties,
+  TextInputProps,
+  ImageProps,
   ScrollViewProps,
-  TextProperties,
-  TouchableHighlightProperties,
-  TouchableNativeFeedbackProperties,
-  TouchableOpacityProperties,
+  TextProps,
+  TouchableHighlightProps,
+  TouchableNativeFeedbackProps,
+  TouchableOpacityProps,
   TouchableWithoutFeedbackProps,
-  FlatListProperties,
-  SectionListProperties
+  FlatListProps,
+  SectionListProps
 } from 'react-native'
 
 export type NativeGlamorousComponentFactory<
   ElementProps,
-  Properties
-> = BuiltInGlamorousComponentFactory<ElementProps, Properties>
+  Props
+> = BuiltInGlamorousComponentFactory<ElementProps, Props>
 
 export interface NativeComponentFactory {
-  image: NativeGlamorousComponentFactory<ImageProperties, ImageStyle>
+  image: NativeGlamorousComponentFactory<ImageProps, ImageStyle>
   scrollView: NativeGlamorousComponentFactory<ScrollViewProps, ViewStyle>
-  text: NativeGlamorousComponentFactory<TextProperties, TextStyle>
-  textInput: NativeGlamorousComponentFactory<TextInputProperties, TextStyle>
+  text: NativeGlamorousComponentFactory<TextProps, TextStyle>
+  textInput: NativeGlamorousComponentFactory<TextInputProps, TextStyle>
   touchableHighlight: NativeGlamorousComponentFactory<
-    TouchableHighlightProperties,
+    TouchableHighlightProps,
     ViewStyle
   >
   touchableNativeFeedback: NativeGlamorousComponentFactory<
-    TouchableNativeFeedbackProperties,
+    TouchableNativeFeedbackProps,
     ViewStyle
   >
   touchableOpacity: NativeGlamorousComponentFactory<
-    TouchableOpacityProperties,
+    TouchableOpacityProps,
     ViewStyle
   >
   touchableWithoutFeedback: NativeGlamorousComponentFactory<
     TouchableWithoutFeedbackProps,
     ViewStyle
   >
-  view: NativeGlamorousComponentFactory<ViewProperties, ViewStyle>
-  flatList: NativeGlamorousComponentFactory<FlatListProperties<any>, ViewStyle>
+  view: NativeGlamorousComponentFactory<ViewProps, ViewStyle>
+  flatList: NativeGlamorousComponentFactory<FlatListProps<any>, ViewStyle>
   sectionList: NativeGlamorousComponentFactory<
-    SectionListProperties<any>,
+    SectionListProps<any>,
     ViewStyle
   >
 }

--- a/typings/built-in-glamorous-components.d.ts
+++ b/typings/built-in-glamorous-components.d.ts
@@ -1,54 +1,54 @@
 import { ExtraGlamorousProps } from './glamorous-component'
 
 import {
-  ViewProperties,
+  ViewProps,
   TextStyle,
   ViewStyle,
   ImageStyle,
-  TextInputProperties,
-  ImageProperties,
+  TextInputProps,
+  ImageProps,
   ScrollViewProps,
-  TextProperties,
-  TouchableHighlightProperties,
-  TouchableNativeFeedbackProperties,
-  TouchableOpacityProperties,
+  TextProps,
+  TouchableHighlightProps,
+  TouchableNativeFeedbackProps,
+  TouchableOpacityProps,
   TouchableWithoutFeedbackProps,
-  FlatListProperties,
-  SectionListProperties
+  FlatListProps,
+  SectionListProps
 } from 'react-native'
 
 export interface NativeComponent {
   Image: React.StatelessComponent<
-    ImageProperties & ExtraGlamorousProps & ImageStyle
+    ImageProps & ExtraGlamorousProps & ImageStyle
   >
   ScrollView: React.StatelessComponent<
     ScrollViewProps & ExtraGlamorousProps & ViewStyle
   >
   Text: React.StatelessComponent<
-    TextProperties & ExtraGlamorousProps & TextStyle
+    TextProps & ExtraGlamorousProps & TextStyle
   >
   TextInput: React.StatelessComponent<
-    TextInputProperties & ExtraGlamorousProps & TextStyle
+    TextInputProps & ExtraGlamorousProps & TextStyle
   >
   TouchableHighlight: React.StatelessComponent<
-    TouchableHighlightProperties & ExtraGlamorousProps & ViewStyle
+    TouchableHighlightProps & ExtraGlamorousProps & ViewStyle
   >
   TouchableNativeFeedback: React.StatelessComponent<
-    TouchableNativeFeedbackProperties & ExtraGlamorousProps & ViewStyle
+    TouchableNativeFeedbackProps & ExtraGlamorousProps & ViewStyle
   >
   TouchableOpacity: React.StatelessComponent<
-    TouchableOpacityProperties & ExtraGlamorousProps & ViewStyle
+    TouchableOpacityProps & ExtraGlamorousProps & ViewStyle
   >
   TouchableWithoutFeedback: React.StatelessComponent<
     TouchableWithoutFeedbackProps & ExtraGlamorousProps & ViewStyle
   >
   View: React.StatelessComponent<
-    ViewProperties & ExtraGlamorousProps & ViewStyle
+    ViewProps & ExtraGlamorousProps & ViewStyle
   >
   FlatList: React.StatelessComponent<
-    FlatListProperties<any> & ExtraGlamorousProps & ViewStyle
+    FlatListProps<any> & ExtraGlamorousProps & ViewStyle
   >
   SectionList: React.StatelessComponent<
-    SectionListProperties<any> & ExtraGlamorousProps & ViewStyle
+    SectionListProps<any> & ExtraGlamorousProps & ViewStyle
   >
 }


### PR DESCRIPTION

The RN typings have a breaking change for a few versions now.

All types like "ViewProperties" are now "ViewProps".

The following:

`import { ViewProperties } from 'react-native'` must be replaced by `import { ViewProps } from 'react-native'`

I don't know exactly when this breaking change happened but it's already been a while it seems. It would be cool to publish a new version with this fix.

I've found this that seems to try to bring retrocompatibility somehow, but not sure how it's supposed to be used:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/legacy-properties.d.ts